### PR TITLE
Shading javax.mail and its dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,8 +202,28 @@
                         </goals>
                     </execution>
                 </executions>
-      </plugin>
-            
+            </plugin>
+            <!-- JAR dependency addition plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>javax.*:*</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
         <!-- Plugin management -->


### PR DESCRIPTION
Added the shade plugin to pom.xml, configured to shade javax.mail:mail and its dependency: javax.activation:activation
